### PR TITLE
fix: correct redirect route for role creation

### DIFF
--- a/app/Http/Controllers/Dashboard/RoleController.php
+++ b/app/Http/Controllers/Dashboard/RoleController.php
@@ -97,7 +97,7 @@ class RoleController extends Controller
 
         Role::create($validatedData);
 
-        return Redirect::route('roles.index')->with('success', 'Role has been created!');
+        return Redirect::route('role.index')->with('success', 'Role has been created!');
     }
 
     public function roleEdit(Int $id)


### PR DESCRIPTION
close #4 
The path was corrected when saving a new role

Before:
![Captura de pantalla 2025-10-30 090029](https://github.com/user-attachments/assets/e958c4ec-8ee8-4223-ab73-24e33cf65cfd)

After:
<img width="1640" height="701" alt="image" src="https://github.com/user-attachments/assets/a7a6ffe3-0fee-4fe7-bde8-fad377fefa6c" />
