### PR TITLE
fix: change product_store validation to integer type

### DIFF
--- a/app/Http/Controllers/Dashboard/ProductController.php
+++ b/app/Http/Controllers/Dashboard/ProductController.php
@@ -69,7 +69,7 @@ class ProductController extends Controller
             'category_id' => 'required|integer',
             'supplier_id' => 'required|integer',
             'product_garage' => 'string|nullable',
-            'product_store' => 'string|nullable',
+            'product_store' => 'integer|nullable',
             'buying_date' => 'date_format:Y-m-d|max:10|nullable',
             'expire_date' => 'date_format:Y-m-d|max:10|nullable',
             'buying_price' => 'required|integer',


### PR DESCRIPTION
The validation of the product stock quantity was changed to integer since it was in string mode