### PR TITLE
fix(cart): add cart item count to response and update UI accordingly

### DIFF
--- a/app/Http/Controllers/Dashboard/OrderController.php
+++ b/app/Http/Controllers/Dashboard/OrderController.php
@@ -135,6 +135,7 @@ class OrderController extends Controller
                     'message' => 'Order created successfully!',
                     'invoice_url' => route('order.invoiceDownload', $order->id),
                     'cart_html' => view('pos.cart-sidebar', ['productItem' => Cart::content()])->render(),
+                    'cart_count' => Cart::count(),
                 ]);
             }
 

--- a/resources/views/pos/index.blade.php
+++ b/resources/views/pos/index.blade.php
@@ -334,6 +334,8 @@
                 if (data.success) {
                     // Update Cart Sidebar HTML
                     document.getElementById('cart-sidebar-container').innerHTML = data.cart_html;
+                    // Update Cart Count Badge
+                    document.getElementById('cart-count-badge').innerText = data.cart_count + ' items';
                 }
             } catch (error) {
                 console.error('Error adding to cart:', error);
@@ -359,6 +361,7 @@
                 const data = await response.json();
                 if (data.success) {
                     document.getElementById('cart-sidebar-container').innerHTML = data.cart_html;
+                    document.getElementById('cart-count-badge').innerText = data.cart_count + ' items';
                 }
             } catch (error) {
                 console.error('Error updating cart:', error);
@@ -379,6 +382,7 @@
                 const data = await response.json();
                 if (data.success) {
                     document.getElementById('cart-sidebar-container').innerHTML = data.cart_html;
+                    document.getElementById('cart-count-badge').innerText = data.cart_count + ' items';
                 }
             } catch (error) {
                 console.error('Error deleting cart:', error);
@@ -523,6 +527,11 @@
                     // Reset UI
                     if (data.cart_html) {
                         document.getElementById('cart-sidebar-container').innerHTML = data.cart_html;
+                    }
+
+                    // Update Cart Count Badge
+                    if (data.cart_count !== undefined) {
+                        document.getElementById('cart-count-badge').innerText = data.cart_count + ' items';
                     }
 
                     // Optional: Reset Pay Input


### PR DESCRIPTION
The problem that the quantity was not being counted in the badge cart-count-badge has been corrected.
<img width="531" height="481" alt="image" src="https://github.com/user-attachments/assets/e5011436-b38a-4abd-84f2-4debe1ad87a2" />
